### PR TITLE
Python 3 compatibility

### DIFF
--- a/python/interpolate_poses.py
+++ b/python/interpolate_poses.py
@@ -137,7 +137,7 @@ def interpolate_poses(pose_timestamps, abs_poses, requested_timestamps, origin_t
     if max(upper_indices) >= len(pose_timestamps):
         upper_indices = [min(i, len(pose_timestamps) - 1) for i in upper_indices]
 
-    fractions = (requested_timestamps - pose_timestamps[lower_indices]) / \
+    fractions = (requested_timestamps - pose_timestamps[lower_indices]) // \
                 (pose_timestamps[upper_indices] - pose_timestamps[lower_indices])
 
     quaternions_lower = abs_quaternions[:, lower_indices]


### PR DESCRIPTION
This ensures that `fractions` is calculated using `np.floor_divide()` as originally intended. As mentioned in https://docs.scipy.org/doc/numpy/reference/generated/numpy.divide.html, using the `/` operator in Python 3 numpy calls `np.true_divide()` rather than `np.floor_divide()`.
Not having this fix produces some `nan` poses.